### PR TITLE
fix(types): custom type creation

### DIFF
--- a/integration/src/providers/commercetools/custom-type/custom-type.service.spec.ts
+++ b/integration/src/providers/commercetools/custom-type/custom-type.service.spec.ts
@@ -62,6 +62,49 @@ describe('CustomTypeService', () => {
     expect(postExecuteMock).toHaveBeenCalled();
   });
 
+  it('should create cart type when get type throws error with 404 response code', async () => {
+    const typeDefinition: TypeDraft = {
+      resourceTypeIds: [],
+      key: 'cartType',
+      name: { en: 'Cart Type' },
+      description: { en: 'Description' },
+      fieldDefinitions: [],
+    };
+
+    getExecuteMock.mockRejectedValue({ code: 404 });
+    postExecuteMock.mockResolvedValue({
+      statusCode: 201,
+      body: typeDefinition,
+    });
+
+    const result = await service.create(typeDefinition);
+
+    expect(result).toEqual(typeDefinition);
+    expect(getExecuteMock).toHaveBeenCalled();
+    expect(postExecuteMock).toHaveBeenCalled();
+  });
+
+  it('should throw error and not create any type when get type fails with non-404 error', async () => {
+    const typeDefinition: TypeDraft = {
+      resourceTypeIds: [],
+      key: 'cartType',
+      name: { en: 'Cart Type' },
+      description: { en: 'Description' },
+      fieldDefinitions: [],
+    };
+
+    getExecuteMock.mockRejectedValue({ code: 401 });
+    postExecuteMock.mockResolvedValue({
+      statusCode: 201,
+      body: typeDefinition,
+    });
+
+    await expect(service.create(typeDefinition)).rejects.toEqual({ code: 401 });
+
+    expect(getExecuteMock).toHaveBeenCalled();
+    expect(postExecuteMock).not.toHaveBeenCalled();
+  });
+
   it('should not create cart type when already exists', async () => {
     const typeDefinition: TypeDraft = {
       resourceTypeIds: [],

--- a/integration/src/providers/commercetools/custom-type/custom-type.service.ts
+++ b/integration/src/providers/commercetools/custom-type/custom-type.service.ts
@@ -11,16 +11,28 @@ export class CustomTypeService {
   async create(typeDefinition: TypeDraft): Promise<Type> {
     const ctClient = this.commercetools.getApiRoot();
 
-    const getType = await ctClient
-      .types()
-      .withKey({ key: typeDefinition.key })
-      .get()
-      .execute();
-    if (getType?.body?.key) {
-      this.logger.log(
-        `Ignoring creation of type '${typeDefinition.key}' as already exists in commercetools`,
-      );
-      return;
+    try {
+      const getType = await ctClient
+        .types()
+        .withKey({ key: typeDefinition.key })
+        .get()
+        .execute();
+      if (getType?.body?.key) {
+        this.logger.log(
+          `Ignoring creation of type '${typeDefinition.key}' as already exists in commercetools`,
+        );
+        return;
+      }
+    } catch (e) {
+      if (e?.code === 404) {
+        this.logger.log(`Type '${typeDefinition.key}' not found creating...`);
+      } else {
+        this.logger.error({
+          message: `Error getting type with key ${typeDefinition.key}`,
+          e,
+        });
+        throw e;
+      }
     }
 
     const response = await ctClient


### PR DESCRIPTION
fix custom type creation to handle scenario where get fails for a 404 with an error instead of returning empty result