### PR TITLE
postman/action.yml: Removing Newman's --bail

### DIFF
--- a/.github/actions/postman/action.yml
+++ b/.github/actions/postman/action.yml
@@ -48,7 +48,7 @@ runs:
       shell: bash
     - name: Run e2e tests
       run: |
-        newman run ${{ inputs.postman_collection_json }} --bail \
+        newman run ${{ inputs.postman_collection_json }} \
           -r htmlextra \
           --reporter-htmlextra-export newman/htmlreport-${{ inputs.ct_project_id }}.html \
           --env-var "client_id=${{ inputs.ct_client_id }}" \


### PR DESCRIPTION
Removing Newman's --bail option in order to enable pipelines to run the full Postman collection even in the presence of failed tests

Test pipeline run >>> https://github.com/Eagle-Eye-Solutions/integration-commerce-tools/actions/runs/7133029383