### PR TITLE
chore: on error set identityValue field empty

### DIFF
--- a/integration/src/providers/commercetools/actions/cart-update/CartCustomTypeActionBuilder.spec.ts
+++ b/integration/src/providers/commercetools/actions/cart-update/CartCustomTypeActionBuilder.spec.ts
@@ -58,6 +58,7 @@ describe('CartCustomTypeActionBuilder', () => {
     const errors: CustomFieldError[] = [
       { type: 'EE_API_DISCONNECTED', message: 'message1' },
       { type: 'EE_API_TIMEOUT', message: 'message2' },
+      { type: 'EE_API_CUSTOMER_NF', message: 'customer not found' },
     ];
 
     const action = CartCustomTypeActionBuilder.setCustomFields({ errors });
@@ -101,6 +102,11 @@ describe('CartCustomTypeActionBuilder', () => {
       {
         action: 'setCustomField',
         name: 'eagleeye-settledStatus',
+        value: '',
+      },
+      {
+        action: 'setCustomField',
+        name: 'eagleeye-identityValue',
         value: '',
       },
     ]);

--- a/integration/src/providers/commercetools/actions/cart-update/CartCustomTypeActionBuilder.ts
+++ b/integration/src/providers/commercetools/actions/cart-update/CartCustomTypeActionBuilder.ts
@@ -130,6 +130,7 @@ export class CartCustomTypeActionBuilder {
       actions.push({
         action: 'setCustomField',
         name: 'eagleeye-identityValue',
+        value: '',
       });
     }
     return actions;

--- a/integration/src/services/event-handler/event-handler.service.ts
+++ b/integration/src/services/event-handler/event-handler.service.ts
@@ -17,7 +17,8 @@ export class EventHandlerService {
   ) {}
 
   async processEvent(message: MessageDeliveryPayload) {
-    this.logger.log('Processing commercetools message');
+    this.logger.log(`Processing commercetools message ${message.id}`);
+    this.logger.debug({ messsage: 'Message', message });
     const actionPromises = await Promise.allSettled(
       this.eventProcessors.map(async (eventProcessor) => {
         await eventProcessor.setMessage(message);


### PR DESCRIPTION
I found a scenario where the identity was not added to the custom fields and failed to remove the `identityValue` custom field as was not present.
Also when we use setCustomType we set identityValue to an empty string so makes sense to keep it consistent  