### PR TITLE
fix: change connect.yaml endpoints to avoid nested paths

### DIFF
--- a/connect.yaml
+++ b/connect.yaml
@@ -1,7 +1,7 @@
 deployAs:
   - name: integration
     applicationType: service
-    endpoint: /cart/service
+    endpoint: /cart-service
     scripts:
       postDeploy: npm install && npm run build && npm run connector:post-deploy:service
       preUndeploy: npm install && npm run build && npm run connector:pre-undeploy:service
@@ -151,7 +151,7 @@ deployAs:
           required: true
   - name: integration_jobs
     applicationType: job
-    endpoint: /jobs/stored-basket-cleanup
+    endpoint: /jobs-stored-basket-cleanup
     properties:
       schedule: "0 * * * 7"
     configuration:

--- a/integration/docs/installation.md
+++ b/integration/docs/installation.md
@@ -44,9 +44,9 @@ and `connector:pre-undeploy:*` scripts.
 
 Extension, Subscription and cleanup job modules share the same source code. The same artifact must be deployed, only different
 endpoints will be used.
-The extension module is triggered via a POST request to `/cart/service`.
+The extension module is triggered via a POST request to `/cart-service`.
 The subscription module is triggered via a POST request to `/events`.
-The cleanup job is triggered via a POST request to `/jobs/stored-basket-cleanup`.
+The cleanup job is triggered via a POST request to `/jobs-stored-basket-cleanup`.
 
 ## Configuration
 

--- a/integration/src/adjudication/adjudication.module.ts
+++ b/integration/src/adjudication/adjudication.module.ts
@@ -45,6 +45,6 @@ export class AdjudicationModule implements NestModule {
   configure(consumer: MiddlewareConsumer): any {
     consumer
       .apply(ExtensionTypeMiddleware, UnidentifiedCustomerMiddleware)
-      .forRoutes({ path: '/cart/service', method: RequestMethod.POST });
+      .forRoutes({ path: '/cart-service', method: RequestMethod.POST });
   }
 }

--- a/integration/src/adjudication/controllers/adjudication.controller.spec.ts
+++ b/integration/src/adjudication/controllers/adjudication.controller.spec.ts
@@ -18,7 +18,7 @@ describe('AdjudicationController', () => {
   });
 
   describe('Extension Request Handler', () => {
-    it('should process POST requests received at /cart/service', async () => {
+    it('should process POST requests received at /cart-service', async () => {
       cartExtensionService.handleCartExtensionRequest.mockReturnValueOnce({
         actions: [],
       } as any);
@@ -29,7 +29,7 @@ describe('AdjudicationController', () => {
   });
 
   describe('Stored Basket Cleanup', () => {
-    it('should process POST requests received at /jobs/stored-basket-cleanup', async () => {
+    it('should process POST requests received at /jobs-stored-basket-cleanup', async () => {
       basketCleanupService.clearOldBaskets.mockResolvedValueOnce({
         results: { successful: [], failed: [] },
       });

--- a/integration/src/adjudication/controllers/adjudication.controller.ts
+++ b/integration/src/adjudication/controllers/adjudication.controller.ts
@@ -10,13 +10,13 @@ export class AdjudicationController {
     private readonly basketCleanupService: BasketCleanupService,
   ) {}
 
-  @Post('/cart/service')
+  @Post('/cart-service')
   @UseFilters(UnhandledExceptionsFilter)
   async handleExtensionRequest(@Body() body): Promise<any> {
     return this.cartExtensionService.handleCartExtensionRequest(body);
   }
 
-  @Post('/jobs/stored-basket-cleanup')
+  @Post('/jobs-stored-basket-cleanup')
   async handleStoredBaskedCleanup(): Promise<any> {
     return this.basketCleanupService.clearOldBaskets();
   }

--- a/integration/src/common/services/commercetools/extension-local.service.ts
+++ b/integration/src/common/services/commercetools/extension-local.service.ts
@@ -69,7 +69,7 @@ export class ExtensionLocalService implements OnModuleInit, OnModuleDestroy {
               action: 'changeDestination',
               destination: {
                 type: 'HTTP',
-                url: `${ngrokUrl}/cart/service`,
+                url: `${ngrokUrl}/cart-service`,
               },
             },
           ],
@@ -77,7 +77,7 @@ export class ExtensionLocalService implements OnModuleInit, OnModuleDestroy {
       } else {
         await this.commercetoolsService.createExtension({
           key: this.extensionKey,
-          destination: { type: 'HTTP', url: `${ngrokUrl}/cart/service` },
+          destination: { type: 'HTTP', url: `${ngrokUrl}/cart-service` },
           triggers: extensions
             .map((ext) =>
               ext.triggers.map((trigger) => {

--- a/integration/test/cart-loyalty.e2e-spec.ts
+++ b/integration/test/cart-loyalty.e2e-spec.ts
@@ -168,7 +168,7 @@ describe('Cart Loyalty processing (e2e)', () => {
     );
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) => expect(res.body).toEqual(LOYALTY_SUCCESS_RESPONSE));
@@ -408,7 +408,7 @@ describe('Cart Loyalty processing (e2e)', () => {
       );
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(itemLevelContinuityCampaignQualifyingCart)
       .expect(201)
       .expect((res) =>
@@ -618,7 +618,7 @@ describe('Cart Loyalty processing (e2e)', () => {
       );
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(itemLevelContinuityCampaignQualifyingCart)
       .expect(201)
       .expect((res) =>
@@ -781,7 +781,7 @@ describe('Cart Loyalty processing (e2e)', () => {
       );
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) =>
@@ -910,7 +910,7 @@ describe('Cart Loyalty processing (e2e)', () => {
       );
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) =>
@@ -1150,7 +1150,7 @@ describe('Cart Loyalty processing (e2e)', () => {
     );
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect(QUEST_LOYALTY_CAMPAIGN_COMPLETING_RESPONSE);
@@ -1320,7 +1320,7 @@ describe('Cart Loyalty processing (e2e)', () => {
     );
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect(QUEST_LOYALTY_CAMPAIGN_INPROGRESS_RESPONSE);

--- a/integration/test/circuit-breaker.e2e-spec.ts
+++ b/integration/test/circuit-breaker.e2e-spec.ts
@@ -83,38 +83,38 @@ describe('Circuit breaker (e2e)', () => {
     );
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) => expect(res.body).toEqual(SUCCESS_RESPONSE));
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) => expect(res.body).toEqual(SUCCESS_RESPONSE));
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) => expect(res.body).toEqual(SUCCESS_RESPONSE));
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) => expect(res.body).toEqual(ERROR_RESPONSE));
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) => expect(res.body).toEqual(ERROR_RESPONSE));
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) => expect(res.body).toEqual(ERROR_RESPONSE));
     // open circuit and save circuit state to CT custom object
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) => expect(res.body).toEqual(ERROR_RESPONSE));
@@ -145,7 +145,7 @@ describe('Circuit breaker (e2e)', () => {
     app = await initAppModule();
 
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(RECALCULATE_CART)
       .expect(201)
       .expect((res) =>

--- a/integration/test/clean-stored-baskets-job.e2e-spec.ts
+++ b/integration/test/clean-stored-baskets-job.e2e-spec.ts
@@ -93,7 +93,7 @@ describe('Clean Stored Enriched Baskets (e2e)', () => {
 
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/jobs/stored-basket-cleanup')
+      .post('/jobs-stored-basket-cleanup')
       .send()
       .expect(201)
       .expect({

--- a/integration/test/eagle-eye-e2e-tests.postman_collection.json
+++ b/integration/test/eagle-eye-e2e-tests.postman_collection.json
@@ -7086,7 +7086,7 @@
 													"});",
 													"",
 													"pm.test(\"'Not Valid' Error is seen under 'eagleeye-errors'\", function () {",
-													"    pm.expect(data.custom.fields['eagleeye-errors'].some(discount => discount.includes('Voucher invalid'))).to.be.true;",
+													"    pm.expect(data.custom.fields['eagleeye-errors'].some(discount => discount.includes('Voucher not found'))).to.be.true;",
 													"});",
 													"",
 													"// pm.collectionVariables.set('customItemDiscountTokenId', data.lineItems[0].id)",

--- a/integration/test/identity-not-found.e2e-spec.ts
+++ b/integration/test/identity-not-found.e2e-spec.ts
@@ -72,7 +72,7 @@ describe('Identity Not Found (e2e)', () => {
 
     app = await initAppModule();
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(cartExtenstionInput)
       .expect(201)
       .expect((res) =>

--- a/integration/test/unidentified-customer.e2e-spec.ts
+++ b/integration/test/unidentified-customer.e2e-spec.ts
@@ -43,7 +43,7 @@ describe('Exclude unidentified customers (e2e)', () => {
     const recalculateCart = JSON.parse(JSON.stringify(RECALCULATE_CART));
     delete recalculateCart.resource.obj.custom.fields;
     await request(app.getHttpServer())
-      .post('/cart/service')
+      .post('/cart-service')
       .send(recalculateCart)
       .expect(200)
       .expect({


### PR DESCRIPTION
[Ticket Jira](https://e2x.atlassian.net/browse/EESD-3)
### Changes 
(eda9c3fcef7ea41d266fc8f3363167b1896539e5) fix: change connect.yaml endpoints to avoid nested paths
(6fa5dad5101452229887919ecbf881a6c6511b6a) fix: test response message when having an invalid voucher
 
This is a workaround for an issue introduced in a recent Connect update.