### PR TITLE
fix: improve error handling/logging for settle/EE API calls

### DIFF
--- a/integration/docs/how-it-works.md
+++ b/integration/docs/how-it-works.md
@@ -448,6 +448,10 @@ Any other errors in the plugin will also be added to the Cart custom field `eagl
 }
 ```
 
+For requests to the EE AIR API, logs include the EE API Unique Call ID (`x-ees-called-unique-id`), which helps troubleshoot issues or unexpected behaviors in AIR that may not be treated/returned as an error. This logged for successful requests and failed requests that reached AIR and provided a response.
+
+Depending on the error, the request payload and/or error response data may be logged as well. These logs can be checked using Connect's [deployment log search](https://docs.commercetools.com/connect/deployment-logs#query-deployment-logs).
+
 ## Subscription module
 
 When performing cart creation/updates (like changing line item quantities, or adding voucher codes) a transaction is

--- a/integration/src/common/config/configuration.ts
+++ b/integration/src/common/config/configuration.ts
@@ -42,6 +42,7 @@ const validationSchema = Joi.object({
   },
   eventHandler: {
     disabledEvents: Joi.array<string>(),
+    allowRetriesOnSettleError: Joi.boolean(),
   },
   storedBasketCleanup: {
     objectQueryLimit: Joi.number(),
@@ -110,6 +111,10 @@ export const defaultConfiguration = {
     disabledEvents: (process.env.CTP_DISABLED_EVENTS || '')
       .split(',')
       .map((item) => item.trim()),
+    allowRetriesOnSettleError: parseBool(
+      process.env.ALLOW_RETRY_ON_SETTLE_ERROR,
+      true,
+    ),
   },
   storedBasketCleanup: {
     objectQueryLimit:

--- a/integration/src/common/exceptions/eagle-eye-api.exception.ts
+++ b/integration/src/common/exceptions/eagle-eye-api.exception.ts
@@ -4,7 +4,10 @@ export type EEApiErrorType =
   | 'EE_API_DISCONNECTED'
   | 'EE_IDENTITY_NOT_FOUND'
   | 'EE_API_SETTLE_POTENTIAL_ISSUES'
-  | 'EE_API_SETTLE_ERROR';
+  | 'EE_API_SETTLE_ERROR'
+  | 'EE_BAD_REQUEST'
+  | 'EE_UNEXPECTED_ERROR'
+  | 'AXIOS_NO_RESPONSE_ERROR';
 
 export class EagleEyeApiException extends Error {
   constructor(

--- a/integration/src/common/helper/axios-payload-utils.spec.ts
+++ b/integration/src/common/helper/axios-payload-utils.spec.ts
@@ -1,0 +1,36 @@
+import { getEesCalledUniqueIdHeader } from './axios-payload-utils';
+
+describe('getEesCalledUniqueIdHeader', () => {
+  it('should return the unique ID from the response headers', () => {
+    const mockResponse = {
+      headers: {
+        'x-ees-called-unique-id': 'unique123',
+      },
+    };
+
+    const result = getEesCalledUniqueIdHeader(mockResponse);
+    expect(result).toBe('unique123');
+  });
+
+  it('should return null if the unique ID header is not present', () => {
+    const mockResponse = {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const result = getEesCalledUniqueIdHeader(mockResponse);
+    expect(result).toBeNull();
+  });
+
+  it('should handle case-insensitive header names', () => {
+    const mockResponse = {
+      headers: {
+        'X-EES-CALLED-UNIQUE-ID': 'unique456',
+      },
+    };
+
+    const result = getEesCalledUniqueIdHeader(mockResponse);
+    expect(result).toBe('unique456');
+  });
+});

--- a/integration/src/common/helper/axios-payload-utils.ts
+++ b/integration/src/common/helper/axios-payload-utils.ts
@@ -1,0 +1,6 @@
+export const getEesCalledUniqueIdHeader = (res: any): string | null => {
+  const header = 'x-ees-called-unique-id';
+  return res.headers
+    ? res.headers[header] || res.headers[header.toUpperCase()] || null
+    : null;
+};

--- a/integration/src/common/providers/eagleeye/eagleeye.provider.spec.ts
+++ b/integration/src/common/providers/eagleeye/eagleeye.provider.spec.ts
@@ -72,8 +72,11 @@ describe('Wallet', () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it('should throw EagleEyeApiException when the API request to EagleEye fails', async () => {
-    const error = { response: { status: 500 } };
+  it('should throw EagleEyeApiException (EE_API_UNAVAILABLE) for unhandled error codes', async () => {
+    const error = {
+      request: { headers: {}, body: {} },
+      response: { headers: {}, status: 500 },
+    };
     jest.spyOn(httpService, 'request').mockImplementationOnce(() => {
       throw error;
     });
@@ -81,7 +84,71 @@ describe('Wallet', () => {
     await expect(service.invoke('open', { test: 'test' })).rejects.toThrow(
       new EagleEyeApiException(
         'EE_API_UNAVAILABLE',
-        'The eagle eye API is unavailable, the cart promotions and loyalty points are NOT updated',
+        'The request failed to be processed by the EE AIR Platform due to an unexpected error.',
+      ),
+    );
+  });
+
+  it('should throw EagleEyeApiException (EE_IDENTITY_NOT_FOUND) for 404 errors', async () => {
+    const error = {
+      request: { headers: {}, body: {} },
+      response: { headers: {}, status: 404 },
+    };
+    jest.spyOn(httpService, 'request').mockImplementationOnce(() => {
+      throw error;
+    });
+
+    await expect(service.invoke('open', { test: 'test' })).rejects.toThrow(
+      new EagleEyeApiException(
+        'EE_IDENTITY_NOT_FOUND',
+        "The customer identity doesn't exist in EE AIR Platform.",
+      ),
+    );
+  });
+
+  it('should throw EagleEyeApiException (EE_BAD_REQUEST) for 400 errors', async () => {
+    const error = {
+      request: { headers: {}, body: {} },
+      response: { headers: {}, status: 400 },
+    };
+    jest.spyOn(httpService, 'request').mockImplementationOnce(() => {
+      throw error;
+    });
+
+    await expect(service.invoke('open', { test: 'test' })).rejects.toThrow(
+      new EagleEyeApiException(
+        'EE_BAD_REQUEST',
+        'The request could not be processed by the EE AIR Platform.',
+      ),
+    );
+  });
+
+  it('should throw EagleEyeApiException (AXIOS_NO_RESPONSE_ERROR) for errors with no response', async () => {
+    const error = {
+      request: { headers: {}, body: {} },
+    };
+    jest.spyOn(httpService, 'request').mockImplementationOnce(() => {
+      throw error;
+    });
+
+    await expect(service.invoke('open', { test: 'test' })).rejects.toThrow(
+      new EagleEyeApiException(
+        'AXIOS_NO_RESPONSE_ERROR',
+        'The request to EE AIR Platform failed but Axios did not include a response.',
+      ),
+    );
+  });
+
+  it('should throw EagleEyeApiException (EE_API_UNAVAILABLE) for other unknown errors', async () => {
+    const error = {};
+    jest.spyOn(httpService, 'request').mockImplementationOnce(() => {
+      throw error;
+    });
+
+    await expect(service.invoke('open', { test: 'test' })).rejects.toThrow(
+      new EagleEyeApiException(
+        'EE_API_UNAVAILABLE',
+        'The EE API is unavailable, the cart promotions and loyalty points are NOT updated.',
       ),
     );
   });

--- a/integration/src/common/providers/eagleeye/eagleeye.provider.ts
+++ b/integration/src/common/providers/eagleeye/eagleeye.provider.ts
@@ -104,13 +104,11 @@ export abstract class EagleEyeSdkObject implements BreakableApi {
               'EE_IDENTITY_NOT_FOUND',
               "The customer identity doesn't exist in EE AIR Platform.",
             );
-            break;
           case 400:
             throw new EagleEyeApiException(
               'EE_BAD_REQUEST',
               'The request could not be processed by the EE AIR Platform.',
             );
-            break;
           default:
             throw new EagleEyeApiException(
               'EE_UNEXPECTED_ERROR',

--- a/integration/test/utils/data/CartExtensionResponse.data.ts
+++ b/integration/test/utils/data/CartExtensionResponse.data.ts
@@ -749,7 +749,7 @@ export const ERROR_RESPONSE = {
       action: 'setCustomField',
       name: 'eagleeye-errors',
       value: [
-        '{"type":"EE_API_UNAVAILABLE","message":"The eagle eye API is unavailable, the cart promotions and loyalty points are NOT updated"}',
+        '{"type":"EE_UNEXPECTED_ERROR","message":"The request failed to be processed by the EE AIR Platform due to an unexpected error."}',
       ],
     },
     { action: 'setCustomField', name: 'eagleeye-appliedDiscounts', value: [] },


### PR DESCRIPTION
- Changed the logs for API requests to only have meaningful information (payloads/responses/unique header).
- Improved error handling.
- Added documentation.
- Added configuration to disallow retrying orders with an errored settle status (only usable on Connect with `CONFIG_OVERRIDE`, intended for dev use).